### PR TITLE
Support BrowserID in screensaver entity if browser_mod is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can set the following configuration parameters for every individual Home Ass
 | control_reactivation_time        | Time in seconds for which interaction with the dashboard is disabled after the screensaver is stopped. | 1.0       |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver ist stopped.          |           |
 | screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). |        |
+| screensaver_entity_browser_mod   | If browser_mod is installed and this is set to true, BrowserID will be appended to screensaver_entity (`screensaver_entity` + `_` + `BrowserID`, ie. `input_boolean.screensaver_b388c16f_5539d2ae`). This allows to control multiple screensavers separately. | false |
 | image_url                        | Fetch screensaver images from this URL. See below for details.                            | See below |
 | image_excludes                   | List of regular expressions for excluding files and directories from local media sources. See below for details. | []        |
 | image_fit                        | Value to be used for the CSS-property 'object-fit' of the images (possible values are: cover / contain / fill / ...). | cover |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can set the following configuration parameters for every individual Home Ass
 | black_screen_after_time          | Time in seconds after which the screensaver will show just a black screen (0 = disabled). | 0         |
 | control_reactivation_time        | Time in seconds for which interaction with the dashboard is disabled after the screensaver is stopped. | 1.0       |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver ist stopped.          |           |
-| screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (allows to control multiple screensavers separately). |        |
+| screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |        |
 | image_url                        | Fetch screensaver images from this URL. See below for details.                            | See below |
 | image_excludes                   | List of regular expressions for excluding files and directories from local media sources. See below for details. | []        |
 | image_fit                        | Value to be used for the CSS-property 'object-fit' of the images (possible values are: cover / contain / fill / ...). | cover |
@@ -88,8 +88,8 @@ You can set the following configuration parameters for every individual Home Ass
 | badges                           | Badges to display in info box. See below for details.                                     | []         |
 | cards                            | Cards to display in info box. See below for details.                                      | See below  |
 | profiles                         | Configuration profiles. See below for details.                                            | {}         |
-| profile                          | Configuration profile to activate.                                                        |            |
-| profile_entity                   | An entity of type 'input_text' used for dynamic activation of profiles.                   |            |
+| profile                          | Configuration profile to activate. If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |            |
+| profile_entity                   | An entity of type 'input_text' used for dynamic activation of profiles. If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |            |
 
 ## Home Assistant Dashboard configuration
 You can add the configuration to your Home Assistant Dashboard configuration yaml (raw config).
@@ -521,6 +521,53 @@ D) An existing user profile is automatically activated if it matches the logged-
 The name of a user profile must start with the string `user.` followed by a user name.
 The username of the logged in user is converted to lowercase and spaces are replaced with `_`.
 Therefore, the username `Jane Doe` will activate the user profile `user.jane_doe`.
+
+
+## Integration with browser_mod
+Normally, it is not possible to set different configuration for different devices. That gap can be closed by integrating WallPanel with [Browser Mod](https://github.com/thomasloven/hass-browser_mod).
+
+Once Browser Mod is correctly installed and configured, Browser ID can be used to define per-device settings.
+
+A separate screensaver entity can exist for each device:
+
+```yaml
+wallpanel:
+  enabled: true
+  screensaver_entity: input_boolean.screensaver_${browser_id}
+```
+
+`${browser_id}` will be replaced with the value of Browser ID (eg. `input_boolean.screensaver_e9a2c86e_5526f1ee`).
+
+A separate profile can be defined for each device:
+
+```yaml
+wallpanel:
+  enabled: true
+  image_order: random
+  profiles:
+    device_e9a2c86e_5526f1ee:
+      image_url: media-source://media_source/local/kitchen
+      screensaver_entity: input_boolean.screensaver_kitchen
+    device_89ae788b_cd883eb1:
+      image_url: media-source://media_source/local/livingroom
+      screensaver_entity: input_boolean.screensaver_livingroom
+  profile: device_${browser_id}
+```
+
+Note: It is not required to define profiles for all devices.
+
+Finally, a separate profile entity can be used for each device:
+
+```yaml
+wallpanel:
+  enabled: true
+  profiles:
+    dogs:
+      image_url: https://source.unsplash.com/random/${width}x${height}?dogs&sig=${timestamp}
+    cats:
+      image_url: https://source.unsplash.com/random/${width}x${height}?cats&sig=${timestamp}
+  profile_entity: input_text.screensaver_profile_${browser_id}
+```
 
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ You can set the following configuration parameters for every individual Home Ass
 | black_screen_after_time          | Time in seconds after which the screensaver will show just a black screen (0 = disabled). | 0         |
 | control_reactivation_time        | Time in seconds for which interaction with the dashboard is disabled after the screensaver is stopped. | 1.0       |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver ist stopped.          |           |
-| screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). |        |
-| screensaver_entity_browser_mod   | If browser_mod is installed and this is set to true, BrowserID will be appended to screensaver_entity (`screensaver_entity` + `_` + `BrowserID`, ie. `input_boolean.screensaver_b388c16f_5539d2ae`). This allows to control multiple screensavers separately. | false |
+| screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (allows to control multiple screensavers separately). |        |
 | image_url                        | Fetch screensaver images from this URL. See below for details.                            | See below |
 | image_excludes                   | List of regular expressions for excluding files and directories from local media sources. See below for details. | []        |
 | image_fit                        | Value to be used for the CSS-property 'object-fit' of the images (possible values are: cover / contain / fill / ...). | cover |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -213,7 +213,7 @@ function updateConfig() {
 		}
 	}
 	config = mergeConfig(config, paramConfig);
-	const profile = this.insertBrowserID(config.profile);
+	const profile = insertBrowserID(config.profile);
 	if (config.profiles && profile && config.profiles[profile]) {
 		config = mergeConfig(config, config.profiles[profile]);
 		if (config.debug) console.debug(`Profile set from config: ${profile}`);
@@ -224,7 +224,7 @@ function updateConfig() {
 		if (config.debug) console.debug(`Profile set from user: ${profile}`);
 	}
 	config = mergeConfig(config, paramConfig);
-	const profile_entity = this.insertBrowserID(config.profile_entity);
+	const profile_entity = insertBrowserID(config.profile_entity);
 	if (config.profiles && profile_entity && elHass.__hass.states[profile_entity] && config.profiles[elHass.__hass.states[profile_entity].state]) {
 		let profile = elHass.__hass.states[profile_entity].state;
 		config = mergeConfig(config, config.profiles[profile]);
@@ -397,6 +397,31 @@ function findImages(hass, mediaContentId) {
 }
 
 
+function insertBrowserID(s) {
+	if (s && window.browser_mod) {
+		if (window.browser_mod.entity_id) {
+			// V1
+			var browserId = window.browser_mod.entity_id;
+		}
+		else if (window.browser_mod.browserID) {
+			// V2
+			var browserId = window.browser_mod.browserID.replace('-', '_');
+		}
+		else {
+			if (config.debug) console.debug(`insertBrowserID(${s}): no BrowserID`);
+			return s;
+		}
+		var res = s.replace("${browser_id}", browserId);
+		if (config.debug) console.debug(`insertBrowserID(${s}): return ${res}`);
+		return res;
+	}
+	else {
+		if (config.debug) console.debug(`insertBrowserID(${s}): no browser_mod or no string`);
+		return s;
+	}
+}
+
+
 document.addEventListener('fullscreenerror', (event) => {
 	console.error('Failed to enter fullscreen');
 });
@@ -448,7 +473,7 @@ class WallpanelView extends HuiView {
 		this.screensaverStoppedAt = new Date();
 		this.idleSince = Date.now();
 		this.bodyOverflowOrig = null;
-		this.lastProfileSet = this.insertBrowserID(config.profile);
+		this.lastProfileSet = insertBrowserID(config.profile);
 		this.lastRandomMove = null;
 		this.translateInterval = null;
 
@@ -471,7 +496,7 @@ class WallpanelView extends HuiView {
 			return;
 		}
 
-		const screensaver_entity = this.insertBrowserID(config.screensaver_entity);
+		const screensaver_entity = insertBrowserID(config.screensaver_entity);
 
 		if (screensaver_entity && this.__hass.states[screensaver_entity]) {
 			let lastChanged = new Date(this.__hass.states[screensaver_entity].last_changed);
@@ -499,32 +524,8 @@ class WallpanelView extends HuiView {
 		return this.__hass;
 	}
 
-	insertBrowserID(s) {
-		if (s && window.browser_mod) {
-			if (window.browser_mod.entity_id) {
-				// V1
-				var browserId = window.browser_mod.entity_id;
-			}
-			else if (window.browser_mod.browserID) {
-				// V2
-				var browserId = window.browser_mod.browserID.replace('-', '_');
-			}
-			else {
-				if (config.debug) console.debug(`insertBrowserID(${s}): no BrowserID`);
-				return s;
-			}
-			var res = s.replace("${browser_id}", browserId);
-			if (config.debug) console.debug(`insertBrowserID(${s}): return ${res}`);
-			retur res;
-		}
-		else {
-			if (config.debug) console.debug(`insertBrowserID(${s}): no browser_mod or no string`);
-			return s;
-		}
-	}
-
 	setScreensaverEntityState() {
-		const screensaver_entity = this.insertBrowserID(config.screensaver_entity);
+		const screensaver_entity = insertBrowserID(config.screensaver_entity);
 		if (!screensaver_entity || !this.__hass.states[screensaver_entity]) return;
 		if (this.screensaverStartedAt && this.__hass.states[screensaver_entity].state == 'on') return;
 		if (!this.screensaverStartedAt && this.__hass.states[screensaver_entity].state == 'off') return;
@@ -542,7 +543,7 @@ class WallpanelView extends HuiView {
 	}
 
 	updateProfile() {
-		const profile_entity = this.insertBrowserID(config.profile_entity);
+		const profile_entity = insertBrowserID(config.profile_entity);
 		if (profile_entity && this.__hass.states[profile_entity]) {
 			const profile = this.__hass.states[profile_entity].state;
 			if ((profile && profile != this.lastProfileSet) || (!profile && this.lastProfileSet)) {

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -124,7 +124,6 @@ const defaultConfig = {
 	control_reactivation_time: 1.0,
 	screensaver_stop_navigation_path: '',
 	screensaver_entity: '',
-	screensaver_entity_browser_mod: false,
 	image_url: "https://picsum.photos/${width}/${height}?random=${timestamp}",
 	image_fit: 'cover', // cover / contain / fill
 	image_list_update_interval: 3600,
@@ -501,19 +500,20 @@ class WallpanelView extends HuiView {
 
         getScreensaverEntity() {
 		if (!config.screensaver_entity) return;
-		if (config.screensaver_entity_browser_mod === true) {
-			if (window.browser_mod) {
-				if (window.browser_mod.entity_id) {
-					// V1
-					return config.screensaver_entity + '_' + window.browser_mod.entity_id;
-				}
-				else if (window.browser_mod.browserID) {
-					// V2
-					return config.screensaver_entity + '_' + window.browser_mod.browserID.replace('-', '_');
-				}
+		if (window.browser_mod) {
+			if (window.browser_mod.entity_id) {
+				// V1
+				var browserId = window.browser_mod.entity_id;
 			}
-			else return;
-                }
+			else if (window.browser_mod.browserID) {
+				// V2
+				var browserId = window.browser_mod.browserID.replace('-', '_');
+			}
+			else {
+				return config.screensaver_entity;
+			}
+			return config.screensaver_entity.replace("${browser_id}", browserId);
+		}
 		else {
 			return config.screensaver_entity;
 		}

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -213,8 +213,8 @@ function updateConfig() {
 		}
 	}
 	config = mergeConfig(config, paramConfig);
-	if (config.profiles && config.profile && config.profiles[config.profile]) {
-		let profile = config.profile;
+	const profile = this.insertBrowserID(config.profile);
+	if (config.profiles && profile && config.profiles[profile]) {
 		config = mergeConfig(config, config.profiles[profile]);
 		if (config.debug) console.debug(`Profile set from config: ${profile}`);
 	}
@@ -224,8 +224,9 @@ function updateConfig() {
 		if (config.debug) console.debug(`Profile set from user: ${profile}`);
 	}
 	config = mergeConfig(config, paramConfig);
-	if (config.profiles && config.profile_entity && elHass.__hass.states[config.profile_entity] && config.profiles[elHass.__hass.states[config.profile_entity].state]) {
-		let profile = elHass.__hass.states[config.profile_entity].state;
+	const profile_entity = this.insertBrowserID(config.profile_entity);
+	if (config.profiles && profile_entity && elHass.__hass.states[profile_entity] && config.profiles[elHass.__hass.states[profile_entity].state]) {
+		let profile = elHass.__hass.states[profile_entity].state;
 		config = mergeConfig(config, config.profiles[profile]);
 		if (config.debug) console.debug(`Profile set from entity state: ${profile}`);
 	}
@@ -447,7 +448,7 @@ class WallpanelView extends HuiView {
 		this.screensaverStoppedAt = new Date();
 		this.idleSince = Date.now();
 		this.bodyOverflowOrig = null;
-		this.lastProfileSet = config.profile;
+		this.lastProfileSet = this.insertBrowserID(config.profile);
 		this.lastRandomMove = null;
 		this.translateInterval = null;
 
@@ -470,7 +471,7 @@ class WallpanelView extends HuiView {
 			return;
 		}
 
-		const screensaver_entity = this.getScreensaverEntity();
+		const screensaver_entity = this.insertBrowserID(config.screensaver_entity);
 
 		if (screensaver_entity && this.__hass.states[screensaver_entity]) {
 			let lastChanged = new Date(this.__hass.states[screensaver_entity].last_changed);
@@ -498,9 +499,8 @@ class WallpanelView extends HuiView {
 		return this.__hass;
 	}
 
-        getScreensaverEntity() {
-		if (!config.screensaver_entity) return;
-		if (window.browser_mod) {
+	insertBrowserID(s) {
+		if (s && window.browser_mod) {
 			if (window.browser_mod.entity_id) {
 				// V1
 				var browserId = window.browser_mod.entity_id;
@@ -510,17 +510,21 @@ class WallpanelView extends HuiView {
 				var browserId = window.browser_mod.browserID.replace('-', '_');
 			}
 			else {
-				return config.screensaver_entity;
+				if (config.debug) console.debug(`insertBrowserID(${s}): no BrowserID`);
+				return s;
 			}
-			return config.screensaver_entity.replace("${browser_id}", browserId);
+			var res = s.replace("${browser_id}", browserId);
+			if (config.debug) console.debug(`insertBrowserID(${s}): return ${res}`);
+			retur res;
 		}
 		else {
-			return config.screensaver_entity;
+			if (config.debug) console.debug(`insertBrowserID(${s}): no browser_mod or no string`);
+			return s;
 		}
-        }
+	}
 
 	setScreensaverEntityState() {
-		const screensaver_entity = this.getScreensaverEntity();
+		const screensaver_entity = this.insertBrowserID(config.screensaver_entity);
 		if (!screensaver_entity || !this.__hass.states[screensaver_entity]) return;
 		if (this.screensaverStartedAt && this.__hass.states[screensaver_entity].state == 'on') return;
 		if (!this.screensaverStartedAt && this.__hass.states[screensaver_entity].state == 'off') return;
@@ -538,8 +542,9 @@ class WallpanelView extends HuiView {
 	}
 
 	updateProfile() {
-		if (config.profile_entity && this.__hass.states[config.profile_entity]) {
-			const profile = this.__hass.states[config.profile_entity].state;
+		const profile_entity = this.insertBrowserID(config.profile_entity);
+		if (profile_entity && this.__hass.states[profile_entity]) {
+			const profile = this.__hass.states[profile_entity].state;
 			if ((profile && profile != this.lastProfileSet) || (!profile && this.lastProfileSet)) {
 				if (config.debug) console.debug(`Set profile to ${profile}`);
 				this.lastProfileSet = profile;


### PR DESCRIPTION
First, let me say that I'm positively shocked with the feature set of this plugin. Previously I used one of the forks and had to make some hacks to get things like navigating when the screensaver kicks in or turning off the screensaver from an automation. I'm so glad all that is now supported natively. Thanks so much!

Now, to the point.

Add option `screensaver_entity_browser_mod` which does the following:

If browser_mod is installed and this is set to true, BrowserID will be appended to screensaver_entity (`screensaver_entity` + `_` + `BrowserID`, ie. `input_boolean.screensaver_b388c16f_5539d2ae`). This allows to control multiple screensavers separately.