### PR TITLE
Navigate when screensaver starts

### DIFF
--- a/wallpanel.js
+++ b/wallpanel.js
@@ -1230,6 +1230,12 @@ class WallpanelView extends HuiView {
 		this.style.opacity = 1;
 
 		this.setScreensaverEntityState();
+
+		setTimeout(() => {
+			if (config.screensaver_stop_navigation_path) {
+				navigate(config.screensaver_stop_navigation_path);
+			}
+		}, (config.fade_in_time+1)*1000);
 	}
 	
 	stopScreensaver() {
@@ -1239,9 +1245,6 @@ class WallpanelView extends HuiView {
 		this.screensaverStoppedAt = Date.now();
 		document.body.style.overflow = this.bodyOverflowOrig;
 		
-		if (config.screensaver_stop_navigation_path) {
-			navigate(config.screensaver_stop_navigation_path);
-		}
 		this.hideMessage();
 
 		this.style.transition = '';

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -1231,11 +1231,11 @@ class WallpanelView extends HuiView {
 
 		this.setScreensaverEntityState();
 
-		setTimeout(() => {
-			if (config.screensaver_stop_navigation_path) {
+		if (config.screensaver_stop_navigation_path) {
+			setTimeout(() => {
 				navigate(config.screensaver_stop_navigation_path);
-			}
-		}, (config.fade_in_time+1)*1000);
+			}, (config.fade_in_time+1)*1000);
+		}
 	}
 	
 	stopScreensaver() {


### PR DESCRIPTION
I think it look better when navigate takes before screensaver turns off. It seems reasonable to do it shortly after the screensaver is activated.