### PR TITLE
Bugfix: both images visible on initial display

### DIFF
--- a/wallpanel.js
+++ b/wallpanel.js
@@ -669,7 +669,7 @@ class WallpanelView extends HuiView {
 		this.imageTwoContainer.style.left = 0;
 		this.imageTwoContainer.style.width = '100%';
 		this.imageTwoContainer.style.height = '100%';
-		this.imageTwoContainer.style.opacity = 1;
+		this.imageTwoContainer.style.opacity = 0;
 		
 		this.imageTwo.removeAttribute('style');
 		this.imageTwo.style.position = 'relative';


### PR DESCRIPTION
When 'image_fit: contain' is set, on initial display both images are visible. If images are of a different size, imageTwo can be seen behind imageOne.

Fix is to hide imageTwo on initial display.