### PR TITLE
Add 'name' property to image info

### DIFF
--- a/wallpanel.js
+++ b/wallpanel.js
@@ -1569,7 +1569,7 @@ class WallpanelView extends HuiView {
 					url: img.imagePath,
 					path: img.imagePath.replace(/^media-source:\/\/[^/]+/, ""),
 					relativePath: img.imagePath.replace(config.image_url, "").replace(/^\/+/, ""),
-					name: img.imagePath.replace(/^.*[\\/]/, ""),
+					filename: img.imagePath.replace(/^.*[\\/]/, ""),
 					folderName: ""
 				};
 				const parts = img.imagePath.split("/");


### PR DESCRIPTION
Added 'name' property that extracts only the name of the image file without folder name.