### PR TITLE
Add new configuration stop_screensaver_on_key_down

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can set the following configuration parameters for every individual Home Ass
 | control_reactivation_time        | Time in seconds for which interaction with the dashboard is disabled after the screensaver is stopped. | 1.0       |
 | stop_screensaver_on_mouse_move   | Stop screensaver on mouse movement?                                                                    | true      |
 | stop_screensaver_on_location_change | Stop screensaver on navigation (location-changed events)?                                           | true      |
+| stop_screensaver_on_key_down     | Stop screensaver on key press?                                                                         | true      |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver is stopped.                        |           |
 | screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |        |
 | show_images                      | Show images if screensaver is active?                                                                  | true      |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -127,6 +127,7 @@ const defaultConfig = {
 	screensaver_stop_navigation_path: '',
 	screensaver_entity: '',
 	stop_screensaver_on_mouse_move: true,
+	stop_screensaver_on_key_down: true,
 	stop_screensaver_on_location_change: true,
 	show_images: true,
 	image_url: "https://picsum.photos/${width}/${height}?random=${timestamp}",
@@ -1395,7 +1396,10 @@ class WallpanelView extends HuiView {
 		shadow.appendChild(this.debugBox);
 
 		const wp = this;
-		let eventNames = ['click', 'touchstart', 'wheel', 'keydown'];
+		let eventNames = ['click', 'touchstart', 'wheel'];		
+		if (config.stop_screensaver_on_key_down) {
+			eventNames.push('keydown');
+		}
 		if (config.stop_screensaver_on_mouse_move) {
 			eventNames.push('mousemove');
 		}


### PR DESCRIPTION
Hello, I need to add this configuration due to the following situation: I have an iPad mounted on the wall that wakes up upon detecting movement, by receiving any key press from a connected Bluetooth keyboard. The iPad wakes up, but WallPanel is triggered by the key press event. I would prefer that it shows WallPanel right after waking up.