### PR TITLE
Add forecast_type to weather card

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ wallpanel:
     - type: weather-forecast
       entity: weather.home
       show_forecast: true
+      forecast_type: daily
 ```
 
 If you want to interact with the cards, as in the dashboard, you can set `card_interaction` to `true`.


### PR DESCRIPTION
The `forecast_type` is required for the weather card.

See [this](https://github.com/home-assistant/home-assistant.io/pull/28636/) HA PR.