### PR TITLE
Added support for '=' character on prefix/suffix

### DIFF
--- a/wallpanel.js
+++ b/wallpanel.js
@@ -1572,19 +1572,20 @@ class WallpanelView extends HuiView {
 				let tmp = tags.split("!");
 				tags = tmp[0];
 				for (let i=1; i<tmp.length; i++) {
-					let tmp2 = tmp[i].split("=", 2);
-					if (tmp2[0] == "prefix") {
-						prefix = tmp2[1];
+					let argType = tmp[i].substring(0, tmp[i].indexOf("="));
+					let argValue = tmp[i].substring(tmp[i].indexOf("=") + 1);
+					if (argType == "prefix") {
+						prefix = argValue;
 					}
-					else if (tmp2[0] == "suffix") {
-						suffix = tmp2[1];
+					else if (argType == "suffix") {
+						suffix = argValue;
 					}
-					else if (tmp2[0] == "options") {
+					else if (argType == "options") {
 						options = {};
-						tmp2[1].split(",").forEach(optVal => {
-							let tmp3 = optVal.split(":", 2);
-							if (tmp3[0] && tmp3[1]) {
-								options[tmp3[0].replace(/\s/g, '')] = tmp3[1].replace(/\s/g, '');
+						argValue.split(",").forEach(optVal => {
+							let tmp2 = optVal.split(":", 2);
+							if (tmp2[0] && tmp2[1]) {
+								options[tmp2[0].replace(/\s/g, '')] = tmp2[1].replace(/\s/g, '');
 							}
 						});
 					}


### PR DESCRIPTION
Hi,

Not all my photos have geolocation exif data, so I was doing the following in order to show / hide an icon as a prefix:
`${address.town|address.city|address.municipality|address.region|address.state|address.village|address.county!prefix=<ha-icon
    icon="mdi:map-marker"></ha-icon>!suffix=}`

That way, if there is geolocation data it shows a marker icon, otherwise it will not.

But it wasn't working, and taking a look to the code I realized there was an issue in the line 1575:
`let tmp2 = tmp[i].split("=", 2)`

The prefix (`<ha-icon icon="mdi:map-marker">`) contains an equals character so the split function was not working correctly (`tmp2[1] = <ha-icon icon`), it was basically missing everything after the '='.

I have made a small change to fix it.

Let me know if that makes sense to you.
Thanks.