### PR TITLE
Respect `image_order = random` for immich

### DIFF
--- a/wallpanel.js
+++ b/wallpanel.js
@@ -1909,7 +1909,11 @@ class WallpanelView extends HuiView {
 							if (album_ids.length == 0) {
 								// All processed
 								if (!wp.cancelUpdatingImageList) {
-									wp.imageList = urls;
+									if (config.image_order == "random") {
+										wp.imageList = urls.sort((a, b) => 0.5 - Math.random());
+									} else {
+										wp.imageList = urls;
+									}
 									imageInfoCache = data;
 									logger.debug("Image list from immich is now:", wp.imageList);
 									if (preload) {


### PR DESCRIPTION
Love the new immich integration!
I expected the images to be randomized when the config `image_order` is set to `random`, so I added that check when the images have been loaded.

I'd argue for changing to `===` and dropping the unused params `(a, b)` but I copied that from the other image shuffle above to keep the code style.