### PR TITLE
Immich performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can set the following configuration parameters for every individual Home Ass
 | image_url                        | Fetch screensaver images from this URL. See below for details.                                         | See below |
 | immich_api_key                   | API key that is used for authentication at the immich API.                                             |           |
 | immich_album_names               | Only show images from these immich albums.                                                             | []        |
+| immich_resolution                | The resolution to use for loading images from immich (possible values are: preview / original).        | preview   |
 | image_excludes                   | List of regular expressions for excluding files and directories from local media sources. See below for details. | []        |
 | image_fit                        | Value to be used for the CSS-property 'object-fit' of the images (possible values are: cover / contain / fill / ...). | cover |
 | image_background                 | If set to `image`, the current image is also displayed as the background over the entire screen. Use the `wallpanel-screensaver-image-background` class to style the background. | color |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -1892,8 +1892,9 @@ class WallpanelView extends HuiView {
 		http.onload = function() {
 			let album_ids = [];
 			if (http.status == 200 || http.status === 0) {
-				logger.debug(`Got immich API response`, http.response);
-				http.response.forEach(album => {
+				const allAlbums = http.response;
+				logger.debug(`Got immich API response`, allAlbums);
+				allAlbums.forEach(album => {
 					logger.debug(album);
 					if (config.immich_album_names && ! config.immich_album_names.includes(album.albumName)) {
 						logger.debug("Skipping album: ", album.albumName);
@@ -1912,16 +1913,16 @@ class WallpanelView extends HuiView {
 						http2.setRequestHeader("x-api-key", config.immich_api_key);
 						http2.onload = function() {
 							if (http2.status == 200 || http2.status === 0) {
-								logger.debug(`Got immich API response`, http2.response);
-								http2.response.assets.forEach(asset => {
+								const albumDetails = http2.response;
+								logger.debug(`Got immich API response`, albumDetails);
+								albumDetails.assets.forEach(asset => {
 									logger.debug(asset);
 									if (asset.type == "IMAGE") {
 										const url = `${api_url}/assets/${asset.id}/original`;
 										data[url] = asset.exifInfo;
-										data[url]["immich"] = JSON.parse(JSON.stringify(asset));
 										data[url]["image"] = {
 											"filename": asset.originalFileName,
-											"folderName": http2.response.albumName
+											"folderName": albumDetails.albumName
 										}
 										urls.push(url);
 									}

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -136,6 +136,7 @@ const defaultConfig = {
 	image_url: "https://picsum.photos/${width}/${height}?random=${timestamp}",
 	immich_api_key: "",
 	immich_album_names: [],
+	immich_resolution: "preview",
 	image_fit: 'cover', // cover / contain / fill
 	image_list_update_interval: 3600,
 	image_order: 'sorted', // sorted / random
@@ -1886,6 +1887,7 @@ class WallpanelView extends HuiView {
 		let data = {};
 		const api_url = config.image_url.replace(/^immich\+/, "");
 		const http = new XMLHttpRequest();
+		const resolution = config.immich_resolution == "original" ? "original" : "thumbnail?size=preview"
 		http.responseType = "json";
 		http.open("GET", `${api_url}/albums`, true);
 		http.setRequestHeader("x-api-key", config.immich_api_key);
@@ -1918,7 +1920,7 @@ class WallpanelView extends HuiView {
 								albumDetails.assets.forEach(asset => {
 									logger.debug(asset);
 									if (asset.type == "IMAGE") {
-										const url = `${api_url}/assets/${asset.id}/original`;
+										const url = `${api_url}/assets/${asset.id}/${resolution}`;
 										data[url] = asset.exifInfo;
 										data[url]["image"] = {
 											"filename": asset.originalFileName,


### PR DESCRIPTION
This PR aims to improve the performance of the Immich integration in 2 ways:

1. Improve the performance when loading an album that contains thousands of pictures (especially noticeable on an underpowered tablet)
2. Load the `preview` resolution by default instead of the `original` resolution. This reduces bandwidth/memory/CPU usage. I think that the tradeoff is worth it, since the `preview` resolution is actually pretty decent (seems to target a side of 1440 pixels).