### PR TITLE
Added new option disable_screensaver_on_browser_mod_popup_func

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can set the following configuration parameters for every individual Home Ass
 | stop_screensaver_on_location_change | Stop screensaver on navigation (location-changed events)?                                           | true      |
 | stop_screensaver_on_key_down     | Stop screensaver on key press?                                                                         | true      |
 | disable_screensaver_on_browser_mod_popup     | Disable screensaver if a browser mod popup is active?                                      | false     |
+| disable_screensaver_on_browser_mod_popup_func| Javascript function to determine whether to disable screensaver based on active browser mod popup ([see below](#disable-screensaver-on-browser-mod-popup-func)) |    |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver is stopped.                        |           |
 | screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |        |
 | show_images                      | Show images if screensaver is active?                                                                  | true      |
@@ -788,6 +789,18 @@ You can stop the screensaver with the javascript code below from a browser mod s
 
 ```javascript
 document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").stopScreensaver();
+```
+
+### disable_screensaver_on_browser_mod_popup_func
+
+You can use this option to conditionally disable the screensaver based on the active browser mod popup. Use the variable `bmp` to select the popup element.
+
+As an example, this javascript will only disable the screensaver if the active browser mod popup contains a `webrtc-camera` card:
+
+```javascript
+disable_screensaver_on_browser_mod_popup_func: |
+  let elements = bmp.shadowRoot.querySelector(".container").children;
+  return Array.from(elements).some(n => n.nodeName.toLowerCase() === "webrtc-camera");
 ```
 
 # FAQ - Frequently Asked Questions

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can set the following configuration parameters for every individual Home Ass
 | stop_screensaver_on_location_change | Stop screensaver on navigation (location-changed events)?                                           | true      |
 | stop_screensaver_on_key_down     | Stop screensaver on key press?                                                                         | true      |
 | disable_screensaver_on_browser_mod_popup     | Disable screensaver if a browser mod popup is active?                                      | false     |
-| disable_screensaver_on_browser_mod_popup_func| Javascript function to determine whether to disable screensaver based on active browser mod popup ([see below](#disable-screensaver-on-browser-mod-popup-func)) |    |
+| disable_screensaver_on_browser_mod_popup_func| Javascript function to determine whether to disable screensaver based on active browser mod popup ([see below](#disable_screensaver_on_browser_mod_popup_func)) |    |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver is stopped.                        |           |
 | screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |        |
 | show_images                      | Show images if screensaver is active?                                                                  | true      |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -132,6 +132,7 @@ const defaultConfig = {
 	stop_screensaver_on_key_down: true,
 	stop_screensaver_on_location_change: true,
 	disable_screensaver_on_browser_mod_popup: false,
+	disable_screensaver_on_browser_mod_popup_func: '',
 	show_images: true,
 	image_url: "https://picsum.photos/${width}/${height}?random=${timestamp}",
 	immich_api_key: "",
@@ -471,6 +472,12 @@ function isActive() {
 	if (config.enabled_on_tabs && config.enabled_on_tabs.length > 0 && activeTab && !config.enabled_on_tabs.includes(activeTab)) {
 		return false;
 	}
+	if (wallpanel &&
+		wallpanel.disable_screensaver_on_browser_mod_popup_function &&
+		getActiveBrowserModPopup() &&
+		wallpanel.disable_screensaver_on_browser_mod_popup_function(getActiveBrowserModPopup())) {
+		return false;
+	}
 	if (config.disable_screensaver_on_browser_mod_popup && getActiveBrowserModPopup()) {
 		return false;
 	}
@@ -691,6 +698,7 @@ class WallpanelView extends HuiView {
 		this.energyCollectionUpdateInterval = 60;
 		this.lastEnergyCollectionUpdate = 0;
 		this.screensaverStopNavigationPathTimeout = null;
+		this.disable_screensaver_on_browser_mod_popup_function = null;
 
 		this.lovelace = null;
 		this.__hass = elHass.__hass;
@@ -1503,6 +1511,10 @@ class WallpanelView extends HuiView {
 				this.imageList = [];
 				this.preloadImages(preloadCallback);
 			}
+		}
+
+		if (config.disable_screensaver_on_browser_mod_popup_func) {
+			this.disable_screensaver_on_browser_mod_popup_function = new Function('bmp', config.disable_screensaver_on_browser_mod_popup_func);
 		}
 	}
 


### PR DESCRIPTION
Added new option `disable_screensaver_on_browser_mod_popup_func` that allows a js condition to be passed to decide whether to disable the screensaver or not, based on the active browser mod popup.

In the below example, i'm using it to only disable the screensaver if there is a `webrtc-camera` card in the popup. The `bmp` variable is pre-assigned the browser mod popup element, ready to use.

```yaml
disable_screensaver_on_browser_mod_popup_func: |
      let elements = bmp.shadowRoot.querySelector(".container").children;
      return Array.from(elements).some(n => n.nodeName.toLowerCase() === "webrtc-camera");
```

Please let me know what you think?

Thanks