### PR TITLE
Added new option screensaver_stop_close_browser_mod_popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can set the following configuration parameters for every individual Home Ass
 | disable_screensaver_on_browser_mod_popup     | Disable screensaver if a browser mod popup is active?                                      | false     |
 | disable_screensaver_on_browser_mod_popup_func| Javascript function to determine whether to disable screensaver based on active browser mod popup ([see below](#disable_screensaver_on_browser_mod_popup_func)) |    |
 | screensaver_stop_navigation_path | Path to navigate to (e.g., /lovelace/default_view) when screensaver is stopped.                        |           |
+| screensaver_stop_close_browser_mod_popup | Close the active browser mod popup when screensaver is stopped?                                | false     |
 | screensaver_entity               | An entity of type 'input_boolean' to reflect and change the screensaver state (on = started, off = stopped). If browser_mod is installed, `${browser_id}` will be replaced with Browser ID (see below). |        |
 | show_images                      | Show images if screensaver is active?                                                                  | true      |
 | image_url                        | Fetch screensaver images from this URL. See below for details.                                         | See below |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -126,6 +126,7 @@ const defaultConfig = {
 	black_screen_after_time: 0,
 	control_reactivation_time: 1.0,
 	screensaver_stop_navigation_path: '',
+	screensaver_stop_close_browser_mod_popup: false,
 	screensaver_entity: '',
 	stop_screensaver_on_mouse_move: true,
 	stop_screensaver_on_mouse_click: true,
@@ -2305,13 +2306,21 @@ class WallpanelView extends HuiView {
 
 		this.setScreensaverEntityState();
 
-		if (config.screensaver_stop_navigation_path) {
+		if (config.screensaver_stop_navigation_path || config.screensaver_stop_close_browser_mod_popup) {
 			this.screensaverStopNavigationPathTimeout = setTimeout(() => {
-				skipDisableScreensaverOnLocationChanged = true;
-				navigate(config.screensaver_stop_navigation_path);
-				setTimeout(() => {
-					skipDisableScreensaverOnLocationChanged = false;
-				}, 250);
+				if (config.screensaver_stop_navigation_path) {
+					skipDisableScreensaverOnLocationChanged = true;
+					navigate(config.screensaver_stop_navigation_path);
+					setTimeout(() => {
+						skipDisableScreensaverOnLocationChanged = false;
+					}, 250);
+				}
+				if (config.screensaver_stop_close_browser_mod_popup) {
+					let bmp = getActiveBrowserModPopup();
+					if (bmp) {
+						bmp.closeDialog();
+					}
+				}
 			}, (config.fade_in_time + 1) * 1000);
 		}
 	}


### PR DESCRIPTION
Added a new option that closes the active browser mod popup after the screensaver has started, very similar to what `screensaver_stop_navigation_path` does.

For context, `screensaver_stop_navigation_path` usually already does this by navigating back to the "home" view, but if you're already on this view when the screensaver starts, the popup would remain. So I added this new option to cover this case.

Please let me know what you think?

Thanks