### PR TITLE
Add support for video medias

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can set the following configuration parameters for every individual Home Ass
 | image_animation_ken_burns        | Apply a Ken Burns effect (panning and zooming) to the images?                                          | false      |
 | image_animation_ken_burns_zoom   | Zoom level for the Ken Burns effect.                                                                   | 1.3        |
 | image_animation_ken_burns_delay  | Start Ken Burns effect with a delay (in seconds).                                                      | 0          |
+| video_loop                       | Loop video until 'display_time' is reached? Otherwise, immediately switch to the next media at the end of the video playback.  | false     |
 | show_image_info                  | Show image info (EXIF / API) on top of image? Only available for local jpeg images containing EXIF data and images from the new Unsplash API. The config name was `show_exif_info` before version 4.7. | false      |
 | show_progress_bar                | Show animated progress bar towards next image being displayed?                                         | false      |
 | fetch_address_data               | Fetch address data for EXIF GPS coordinates from nominatim.openstreetmap.org?                          | false      |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -2415,7 +2415,7 @@ class WallpanelView extends HuiView {
 				this.loadMediaFromUrl(img, src, "IMG");
 			},
 			error => {
-				logger.error(`media_source/resolve_media error for ${imageUrl}:`, error);
+				logger.error(`media_source/resolve_media error for ${img.imageUrl}:`, error);
 			}
 		);
 	}

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -2031,9 +2031,9 @@ class WallpanelView extends HuiView {
 		}
 	}
 
-	findImages(mediaContentId) {
+	findMedias(mediaContentId) {
 		const wp = this;
-		logger.debug(`findImages: ${mediaContentId}`);
+		logger.debug(`findMedias: ${mediaContentId}`);
 		let excludeRegExp = [];
 		if (config.image_excludes) {
 			for (let imageExclude of config.image_excludes) {
@@ -2056,7 +2056,7 @@ class WallpanelView extends HuiView {
 									return;
 								}
 							}
-							if (child.media_class == "image") {
+							if (["image", "video"].includes(child.media_class)) {
 								//logger.debug(child);
 								return child.media_content_id;
 							}
@@ -2064,7 +2064,7 @@ class WallpanelView extends HuiView {
 								if (wp.cancelUpdatingImageList) {
 									return;
 								}
-								return wp.findImages(child.media_content_id);
+								return wp.findMedias(child.media_content_id);
 							}
 						});
 						Promise.all(promises).then(results => {
@@ -2091,7 +2091,7 @@ class WallpanelView extends HuiView {
 		this.lastImageListUpdate = Date.now();
 		const mediaContentId = config.image_url;
 		const wp = this;
-		wp.findImages(mediaContentId).then(
+		wp.findMedias(mediaContentId).then(
 			result => {
 				wp.updatingImageList = false;
 				if (!wp.cancelUpdatingImageList) {
@@ -2412,7 +2412,10 @@ class WallpanelView extends HuiView {
 					src = `${document.location.origin}${src}`;
 				}
 				logger.debug(`Setting image src: ${src}`);
-				this.loadMediaFromUrl(img, src, "IMG");
+
+				const matchedType = result.mime_type?.match(/^(image|video)\//);
+				const mediaType = {"image": "IMG", "video": "VIDEO"}[matchedType?.[1]] || null;
+				this.loadMediaFromUrl(img, src, mediaType);
 			},
 			error => {
 				logger.error(`media_source/resolve_media error for ${img.imageUrl}:`, error);

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -2290,7 +2290,11 @@ class WallpanelView extends HuiView {
 			const fallbackTag = currentElem.tagName === "IMG" ? "VIDEO" : "IMG";
 			const fallbackElem = document.createElement(fallbackTag);
 
-			// Clone all attributes except 'src', it will be set later.
+			// Clone all custom and HTML attributes except 'src', it will be set later.
+			Object.entries(currentElem)
+				.filter(([key]) => !(key in HTMLElement.prototype))
+				.forEach(([key, value]) => fallbackElem[key] = value);
+
 			[...currentElem.attributes]
 				.filter((attr) => attr.name !== "src")
 				.forEach((attr) => fallbackElem.setAttribute(attr.name, attr.value));


### PR DESCRIPTION
Hello @j-a-n,

First, thank you for this great extension!

This PR introduces support for playing videos in addition to showing images, similar to the Apple Aerials screensaver.

- HTTP URLs are supported, e.g. http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4.
- media-source URLs are supported, e.g. `media-source://media_source/some_folder_with_video_medias`.
- I did not add support for playing videos from immich. Handling video playback with immich authentication seemed complex.

Additionally, I also made a minor fix that I detected while testing https://github.com/j-a-n/lovelace-wallpanel/commit/29b287fcea5c9e68c5fb1fbc8b0d5a1bea59cafd#diff-b8fc5817efeac15f75ef963af64dfa47ce6d95ddaf214c51626febedb8fc9c09R2418.

Lastly, there are still few places in the code that use the term `image`, where a more generic term like `media` might now be appropriate. I avoided making too many changes in this PR, but I'd be happy to update this if you prefer

Best regards,
Julien