### PR TITLE
Immich use shared albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can set the following configuration parameters for every individual Home Ass
 | immich_api_key                   | API key that is used for authentication at the immich API.                                             |           |
 | immich_album_names               | Only show images from these immich albums.                                                             | []        |
 | immich_resolution                | The resolution to use for loading images from immich (possible values are: preview / original).        | preview   |
+| immich_shared                    | Use shared albums                                                                                      | false     |
 | image_excludes                   | List of regular expressions for excluding files and directories from local media sources. See below for details. | []        |
 | image_fit                        | Value to be used for the CSS-property 'object-fit' of the images (possible values are: cover / contain / fill / ...). | cover |
 | image_background                 | If set to `image`, the current image is also displayed as the background over the entire screen. Use the `wallpanel-screensaver-image-background` class to style the background. | color |

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -245,6 +245,7 @@ const defaultConfig = {
 	immich_api_key: '',
 	immich_album_names: [],
 	immich_resolution: "preview",
+	immich_shared: "false",
 	image_fit: 'cover', // cover / contain / fill
 	image_list_update_interval: 3600,
 	image_order: 'sorted', // sorted / random
@@ -2146,9 +2147,10 @@ class WallpanelView extends HuiView {
 		let data = {};
 		const api_url = config.image_url.replace(/^immich\+/, "");
 		const http = new XMLHttpRequest();
+		const shared = config.immich_shared ? "shared=true" : "shared=false";
 		const resolution = config.immich_resolution == "original" ? "original" : "thumbnail?size=preview"
 		http.responseType = "json";
-		http.open("GET", `${api_url}/albums`, true);
+		http.open("GET", `${api_url}/albums` + shared, true);
 		http.setRequestHeader("x-api-key", config.immich_api_key);
 		http.onload = function() {
 			let album_ids = [];

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -245,7 +245,7 @@ const defaultConfig = {
 	immich_api_key: '',
 	immich_album_names: [],
 	immich_resolution: "preview",
-	immich_shared: false,
+	immich_shared: "false",
 	image_fit: 'cover', // cover / contain / fill
 	image_list_update_interval: 3600,
 	image_order: 'sorted', // sorted / random
@@ -2147,7 +2147,7 @@ class WallpanelView extends HuiView {
 		let data = {};
 		const api_url = config.image_url.replace(/^immich\+/, "");
 		const http = new XMLHttpRequest();
-		const shared = "?shared=false";
+		let shared = "?shared=false";
 		if (config.immich_shared) {
 			shared = "?shared=true";
 		}

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -2148,8 +2148,9 @@ class WallpanelView extends HuiView {
 		const api_url = config.image_url.replace(/^immich\+/, "");
 		const http = new XMLHttpRequest();
 		const shared = "?shared=false";
-		if(config.immich_shared && config.immich_shared == "true")
+		if (config.immich_shared) {
 			shared = "?shared=true";
+		}
 		const resolution = config.immich_resolution == "original" ? "original" : "thumbnail?size=preview"
 		http.responseType = "json";
 		http.open("GET", `${api_url}/albums` + shared, true);

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -2147,7 +2147,9 @@ class WallpanelView extends HuiView {
 		let data = {};
 		const api_url = config.image_url.replace(/^immich\+/, "");
 		const http = new XMLHttpRequest();
-		const shared = config.immich_shared ? "shared=true" : "shared=false";
+		const shared = "?shared=false";
+		if(config.immich_shared && config.immich_shared == "true")
+			shared = "?shared=true";
 		const resolution = config.immich_resolution == "original" ? "original" : "thumbnail?size=preview"
 		http.responseType = "json";
 		http.open("GET", `${api_url}/albums` + shared, true);

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -2162,7 +2162,7 @@ class WallpanelView extends HuiView {
 				logger.debug(`Got immich API response`, allAlbums);
 				allAlbums.forEach(album => {
 					logger.debug(album);
-					if (config.immich_album_names && ! config.immich_album_names.includes(album.albumName)) {
+					if (config.immich_album_names.length && ! config.immich_album_names.includes(album.albumName)) {
 						logger.debug("Skipping album: ", album.albumName);
 					}
 					else {

--- a/wallpanel.js
+++ b/wallpanel.js
@@ -245,7 +245,7 @@ const defaultConfig = {
 	immich_api_key: '',
 	immich_album_names: [],
 	immich_resolution: "preview",
-	immich_shared: "false",
+	immich_shared: false,
 	image_fit: 'cover', // cover / contain / fill
 	image_list_update_interval: 3600,
 	image_order: 'sorted', // sorted / random


### PR DESCRIPTION
This is a PR to allow the Immich API call to pull shared albums as well.
Variable is immish_shared initialises at false by default.
I have also changed the check for immich_album_names as the absence of album names would not load any album. 