### PR TITLE
Fix x-api-key "undefined" 401s on Immich after list refresh

### DIFF
--- a/wallpanel-src.js
+++ b/wallpanel-src.js
@@ -216,7 +216,7 @@ function addToMediaInfoCache(mediaUrl, value) {
 	if (!Number.isFinite(maxSize) || maxSize <= 0) {
 		return;
 	}
-	while (mediaInfoCache.size >= maxSize) {
+	while (!mediaInfoCache.has(mediaUrl) && mediaInfoCache.size >= maxSize) {
 		// Remove the oldest key (first inserted)
 		const oldestKey = mediaInfoCache.keys().next().value;
 		mediaInfoCache.delete(oldestKey);


### PR DESCRIPTION
`addToMediaInfoCache` evicts an entry *before* calling `.set()`. But when the key already exists, `.set()` just updates it in place — no new slot is needed. The eviction was unnecessary and dropped an unrelated entry.

This matters when the Immich media list refreshes (`media_list_update_interval`, default 3600s). The new random slice of 500 URLs overlaps with what's already cached. Each overlapping URL triggers an eviction + update, so cached entries for *other* URLs keep disappearing. `wp.mediaList` still references those URLs, but their cache entries are gone.

When WallPanel later fetches a thumbnail:
```js
const mediaInfo = mediaInfoCache.get(element.mediaUrl) || {};
fetch(url, { headers: { "x-api-key": mediaInfo["immichApiKey"] } });
