### PR TITLE
Bugfix: image_url_entity not updated when going backwards

### DIFF
--- a/wallpanel-src.js
+++ b/wallpanel-src.js
@@ -1207,6 +1207,7 @@ function initWallpanel() {
 			this.updatingMediaList = false;
 			this.updatingMedia = false;
 			this.lastMediaUpdate = 0;
+			this.lastImageUrlEntityValue = null;
 			this.blockEventsUntil = 0;
 			this.screensaverStartedAt;
 			this.screensaverStoppedAt = new Date();
@@ -1334,7 +1335,7 @@ function initWallpanel() {
 			if (!activeElement || !activeElement.mediaUrl) return;
 			// Maximum length for input_text entity is 255
 			const mediaUrl = activeElement.mediaUrl.substring(0, 255);
-			if (activeElement._lastImageURLEntityValue === mediaUrl) {
+			if (this.lastImageUrlEntityValue === mediaUrl) {
 				return;
 			}
 
@@ -1347,7 +1348,7 @@ function initWallpanel() {
 				.then(
 					(result) => {
 						logger.debug(result);
-						activeElement._lastImageURLEntityValue = mediaUrl;
+						this.lastImageUrlEntityValue = mediaUrl;
 					},
 					(error) => {
 						logger.error("Failed to set image url entity state:", error);


### PR DESCRIPTION
setImageURLEntityState() caches the current image url via _lastImageURLEntityValue per DOM element, but WallPanel alternates between two media elements for crossfading, so backing up one image lands the previous URL on the same element that previously held it, making the guard wrongly conclude nothing changed and skip the image_url_entity update.

Fix is to track in an instance variable.