### PR TITLE
Add nextImage() and previousImage() callable via browser-mod

### DIFF
--- a/docs/browser-mod.md
+++ b/docs/browser-mod.md
@@ -95,3 +95,13 @@ You can stop the screensaver with the javascript code below from a browser mod s
 ```javascript
 document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").stopScreensaver();
 ```
+
+You can also navigate to the next or previous image programmatically:
+
+```javascript
+document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").nextImage();
+```
+
+```javascript
+document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").previousImage();
+```

--- a/wallpanel-src.js
+++ b/wallpanel-src.js
@@ -4132,6 +4132,36 @@ function initWallpanel() {
 			this.switchActiveMedia("user_action");
 		}
 
+		async nextImage() {
+			if (this.updatingMedia) {
+				logger.debug("Already switching media");
+				return;
+			}
+			logger.debug("Next image");
+			const prevDirection = this.mediaListDirection;
+			this.mediaListDirection = "forwards";
+			try {
+				await this.switchActiveMedia("user_action");
+			} finally {
+				this.mediaListDirection = prevDirection;
+			}
+		}
+
+		async previousImage() {
+			if (this.updatingMedia) {
+				logger.debug("Already switching media");
+				return;
+			}
+			logger.debug("Previous image");
+			const prevDirection = this.mediaListDirection;
+			this.mediaListDirection = "backwards";
+			try {
+				await this.switchActiveMedia("user_action");
+			} finally {
+				this.mediaListDirection = prevDirection;
+			}
+		}
+
 		setCameraMotionDetectionEntityState(state) {
 			const entity = config.camera_motion_detection_set_entity;
 			if (!entity || !this.__hass.states[entity]) return;


### PR DESCRIPTION
Add nextImage() and previousImage() for use with browser-mod.

Existing slideshow direction is preserved after the call.