### PR TITLE
Fix for 2026.6 drawer and top bar

### DIFF
--- a/wallpanel-src.js
+++ b/wallpanel-src.js
@@ -1157,18 +1157,25 @@ function setSidebarVisibility(hidden) {
 	try {
 		const drawer = elHaMain.shadowRoot.querySelector("ha-drawer");
 		if (drawer) {
-			const sidebar = drawer.shadowRoot.querySelector("aside");
+			// HA 2026.6+: ha-drawer was rewritten using Webawesome; sidebar is now
+			// .sidebar-shell. Fall back to <aside> for HA < 2026.6.
+			const sidebar = drawer.shadowRoot.querySelector(".sidebar-shell")
+				|| drawer.shadowRoot.querySelector("aside");
+			// CSS variable also changed in 2026.6: --mdc-drawer-width → --ha-sidebar-width
+			const sidebarWidthVar = sidebar && sidebar.classList.contains("sidebar-shell")
+				? "--ha-sidebar-width"
+				: "--mdc-drawer-width";
 			if (sidebar) {
 				if (hidden) {
 					// Using style.display = hidden will cause the companion app to freeze
 					// See https://github.com/j-a-n/lovelace-wallpanel/issues/383
 					sidebar.style.opacity = 0;
 					sidebar.style.maxWidth = "0px";
-					elHaMain.style.setProperty("--mdc-drawer-width", "env(safe-area-inset-left)");
+					elHaMain.style.setProperty(sidebarWidthVar, "env(safe-area-inset-left)");
 				} else {
 					sidebar.style.opacity = 1;
 					sidebar.style.maxWidth = "";
-					elHaMain.style.removeProperty("--mdc-drawer-width");
+					elHaMain.style.removeProperty(sidebarWidthVar);
 				}
 				window.dispatchEvent(new Event("resize"));
 			}


### PR DESCRIPTION
Sorry, this fix and it's description are AI generated. I am able to confirm it works on 2026.6.0b0 but unable to test it on 2026.5.x (it took almost one hour to restore to 2026.5.4 and another hour back to 2026.6.0b0).


# Fix sidebar hiding for Home Assistant 2026.6 (backwards compatible)

## Problem

WallPanel's `hide_sidebar: true` breaks after upgrading to Home Assistant
2026.6.0. The `setSidebarVisibility` function targets two things that changed
in the 2026.6 frontend overhaul:

1. **Wrong shadow DOM selector** — `ha-drawer`'s internal sidebar element was
   previously an `<aside>` element. In 2026.6, `ha-drawer` was rewritten to
   use the Webawesome component, and the sidebar container is now
   `<div class="sidebar-shell">`.

2. **Wrong CSS variable** — The sidebar width was controlled by
   `--mdc-drawer-width`. In 2026.6 this was replaced with `--ha-sidebar-width`.

Reference: [Frontend component updates in 2026.6](https://developers.home-assistant.io/blog/2026/05/27/frontend-component-updates-2026.6/)

## Fix

The fix is backwards-compatible with HA < 2026.6: it tries the new
`.sidebar-shell` selector first and falls back to the old `aside`. The CSS
variable is chosen based on which element was found.

```diff
- var a = i.shadowRoot.querySelector("aside");
- a && (e
-   ? (a.style.opacity=0, a.style.maxWidth="0px",
-      dm.style.setProperty("--mdc-drawer-width", "env(safe-area-inset-left)"))
-   : (a.style.opacity=1, a.style.maxWidth="",
-      dm.style.removeProperty("--mdc-drawer-width")),
-   window.dispatchEvent(new Event("resize")));
+ var a = i.shadowRoot.querySelector(".sidebar-shell")
+       || i.shadowRoot.querySelector("aside");
+ var wp_sidebarVar = a && a.classList.contains("sidebar-shell")
+   ? "--ha-sidebar-width"
+   : "--mdc-drawer-width";
+ a && (e
+   ? (a.style.opacity=0, a.style.maxWidth="0px",
+      dm.style.setProperty(wp_sidebarVar, "env(safe-area-inset-left)"))
+   : (a.style.opacity=1, a.style.maxWidth="",
+      dm.style.removeProperty(wp_sidebarVar)),
+   window.dispatchEvent(new Event("resize")));
```

## What is NOT affected

`hide_toolbar` is unaffected — `div.toolbar` and `div.action-items` are
unchanged in the new `hui-root` implementation.

## Compatibility

| HA version | Sidebar element | CSS variable | Result |
|---|---|---|---|
| < 2026.6 | `aside` | `--mdc-drawer-width` | ✅ fallback path used |
| ≥ 2026.6 | `.sidebar-shell` | `--ha-sidebar-width` | ✅ new path used |
