### PR TITLE
Browser Mod API: Add togglePlayPause() function

### DIFF
--- a/docs/browser-mod.md
+++ b/docs/browser-mod.md
@@ -90,18 +90,21 @@ wallpanel:
 ```
 
 ## Browser Mod service
-You can stop the screensaver with the javascript code below from a browser mod service.
+
+You can call WallPanel functions programmatically from a Browser Mod service using Javascript.
+
+Example of how to call into Wallpanel from Browser Mod:
 
 ```javascript
 document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").stopScreensaver();
 ```
 
-You can also navigate to the next or previous image programmatically:
+### Available functions:
 
-```javascript
-document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").nextImage();
-```
+| Function | Description |
+|---|---|
+| `stopScreensaver()` | Stop the screensaver |
+| `togglePlayPause()` | Play or pause the slideshow |
+| `nextImage()` | Navigate to the next image |
+| `previousImage()` | Navigate to the previous image |
 
-```javascript
-document.querySelector("home-assistant").shadowRoot.querySelector("home-assistant-main").shadowRoot.querySelector("wallpanel-view").previousImage();
-```

--- a/wallpanel-src.js
+++ b/wallpanel-src.js
@@ -1309,6 +1309,8 @@ function initWallpanel() {
 			this.updatingMediaList = false;
 			this.updatingMedia = false;
 			this.lastMediaUpdate = 0;
+			this.isPaused = false;
+			this.mediaTimeElapsedBeforePause = 0;
 			this.lastImageUrlEntityValue = null;
 			this.blockEventsUntil = 0;
 			this.screensaverStartedAt;
@@ -2088,6 +2090,8 @@ function initWallpanel() {
 			setTimeout(function () {
 				// Restart CSS animation.
 				wp.progressBar.style.animation = `horizontalProgress ${config.display_time}s linear`;
+				// Do not advance progress bar if slideshow is paused.
+				wp.progressBar.style.animationPlayState = wp.isPaused ? "paused" : "running";
 			}, 25);
 		}
 
@@ -2291,6 +2295,21 @@ function initWallpanel() {
 			if (config.show_progress_bar) {
 				this.screensaverContainer.appendChild(this.progressBarContainer);
 			}
+
+			this.pauseIndicator = document.createElement("div");
+			this.pauseIndicator.id = "wp-pause-indicator";
+			this.pauseIndicator.innerHTML = "⏸️";
+			this.pauseIndicator.style.position = "absolute";
+			this.pauseIndicator.style.top = "1rem";
+			this.pauseIndicator.style.left = "1rem";
+			this.pauseIndicator.style.fontSize = "4rem";
+			this.pauseIndicator.style.lineHeight = "1";
+			this.pauseIndicator.style.color = "white";
+			this.pauseIndicator.style.filter = "drop-shadow(0 0 8px rgba(0,0,0,0.8))";
+			this.pauseIndicator.style.zIndex = "9999";
+			this.pauseIndicator.style.pointerEvents = "none";
+			this.pauseIndicator.style.display = "none";
+			this.screensaverContainer.appendChild(this.pauseIndicator);
 
 			this.infoContainer = document.createElement("div");
 			this.infoContainer.id = "wallpanel-screensaver-info-container";
@@ -3858,6 +3877,9 @@ function initWallpanel() {
 					logger.debug(`Media entity ${mediaEntity} state unchanged, but media_entity_load_unchanged = true`);
 				} else {
 					this.lastMediaUpdate = Date.now();
+					if (this.isPaused) {
+						this.mediaTimeElapsedBeforePause = 0;
+					}
 					this.restartProgressBarAnimation();
 					return;
 				}
@@ -3865,6 +3887,9 @@ function initWallpanel() {
 			}
 
 			this.lastMediaUpdate = Date.now();
+			if (this.isPaused) {
+				this.mediaTimeElapsedBeforePause = 0;
+			}
 			const activeElement = this.getActiveMediaElement();
 			if (
 				(sourceType === "iframe" || sourceType === "embed") &&
@@ -3894,6 +3919,11 @@ function initWallpanel() {
 
 		_switchActiveMedia(newElement, crossfadeMillis = null) {
 			this.lastMediaUpdate = Date.now();
+			if (this.isPaused) {
+				// Case of calls to nextImage()/previousImage() when slideshow is paused.
+				// Preserve paused state.
+				this.mediaTimeElapsedBeforePause = 0;
+			}
 			this.imageOneContainer.style.transition = `opacity ${crossfadeMillis}ms ease-in-out`;
 			this.imageTwoContainer.style.transition = `opacity ${crossfadeMillis}ms ease-in-out`;
 
@@ -4044,6 +4074,11 @@ function initWallpanel() {
 			this.lastMediaUpdate = Date.now();
 			document.documentElement.style.overflow = "hidden";
 
+			// Reset state relevant to slideshow pause.
+			this.isPaused = false;
+			this.mediaTimeElapsedBeforePause = 0;
+			this.pauseIndicator.style.display = "none";
+
 			this.createInfoBoxContent();
 
 			this.style.visibility = "visible";
@@ -4077,6 +4112,7 @@ function initWallpanel() {
 			return Boolean(this.screensaverStartedAt) && this.screensaverStartedAt > 0;
 		}
 
+		// API for use with Browser Mod.
 		stopScreensaver(fadeOutTime = 0.0) {
 			logger.debug("Stop screensaver");
 
@@ -4148,7 +4184,7 @@ function initWallpanel() {
 				logger.debug("Setting screen to black");
 				this.screensaverOverlay.style.background = "#000000";
 			} else if (config.show_images) {
-				if (now - this.lastMediaUpdate >= config.display_time * 1000) {
+				if (!this.isPaused && now - this.lastMediaUpdate >= config.display_time * 1000) {
 					this.switchActiveMedia("display_time_elapsed");
 				}
 				if (now - this.lastMediaListUpdate >= config.media_list_update_interval * 1000) {
@@ -4250,6 +4286,7 @@ function initWallpanel() {
 			this.switchActiveMedia("user_action");
 		}
 
+		// API for use with Browser Mod.
 		async nextImage() {
 			if (this.updatingMedia) {
 				logger.debug("Already switching media");
@@ -4265,6 +4302,7 @@ function initWallpanel() {
 			}
 		}
 
+		// API for use with Browser Mod.
 		async previousImage() {
 			if (this.updatingMedia) {
 				logger.debug("Already switching media");
@@ -4277,6 +4315,35 @@ function initWallpanel() {
 				await this.switchActiveMedia("user_action");
 			} finally {
 				this.mediaListDirection = prevDirection;
+			}
+		}
+
+		// API for use with Browser Mod.
+		togglePlayPause() {
+			logger.debug("Toggle play/pause");
+
+			if (!this.screensaverRunning()) return;
+
+			if (this.isPaused) {
+				// Play.
+				this.isPaused = false;
+				this.lastMediaUpdate = Date.now() - (this.mediaTimeElapsedBeforePause || 0);
+				this.pauseIndicator.style.display = "none";
+				this.progressBar.style.animationPlayState = "running";
+
+				this.startPlayingActiveMedia();
+			} else {
+				// Pause.
+				this.isPaused = true;
+				this.mediaTimeElapsedBeforePause = Date.now() - this.lastMediaUpdate;
+				this.lastMediaUpdate = Date.now();
+				this.pauseIndicator.style.display = "block";
+				this.progressBar.style.animationPlayState = "paused";
+
+				const videoElement = this.getActiveMediaElement(true);
+				if (videoElement && typeof videoElement.pause === "function") {
+					videoElement.pause();
+				}
 			}
 		}
 


### PR DESCRIPTION
Add a function to allow pausing/playing the slideshow.

Also tweak the documentation a bit for the browser mod API and add comments above API functions.

### When pausing the slideshow
1. A visual pause indicator is displayed.
1. Progress bar animation is stopped (does not advance).
1. If a video is playing the video is paused.
1. nextImage()/previousImage() calls continue to work but do not unpause the slideshow.
2. restarting the slideshow will clear the paused state and continue to play.

### When unpausing the slideshow:
1. media will display for the remaining time it has left before the pause.
1. Progress bar animation will continue from same location.
1. videos will continue to play.