### PR TITLE
Fix babel.config.json corejs version mismatch

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -4,7 +4,7 @@
 			"@babel/preset-env",
 			{
 				"useBuiltIns": "usage",
-				"corejs": "3.40"
+				"corejs": "3.43"
 			}
 		]
 	]


### PR DESCRIPTION
The babel.config.json specifies corejs: "3.40" but the installed core-js version (from package.json) is ^3.43.0, and the lockfile confirms 3.43.0. This mismatch can cause polyfill resolution issues. Updated babel.config.json to use "3.43" to match the actual installed version.